### PR TITLE
(PE-21788) Open port 8170 on ec2 masters

### DIFF
--- a/lib/beaker/hypervisor/ec2_helper.rb
+++ b/lib/beaker/hypervisor/ec2_helper.rb
@@ -20,6 +20,7 @@ module Beaker
       if roles.include? 'master'
         ports << 8140
         ports << 8142
+        ports << 8170
       end
 
       if roles.include? 'dashboard'

--- a/spec/beaker/hypervisor/ec2_helper_spec.rb
+++ b/spec/beaker/hypervisor/ec2_helper_spec.rb
@@ -30,7 +30,7 @@ describe Beaker::EC2Helper do
     end
 
     it "can set ports for master host" do
-      expect(ec2.amiports(master_host)).to be === [22, 61613, 8139, 8140, 8142, 9999]
+      expect(ec2.amiports(master_host)).to be === [22, 61613, 8139, 8140, 8142, 8170, 9999]
     end
 
     it "can set ports for dashboard host" do
@@ -38,7 +38,7 @@ describe Beaker::EC2Helper do
     end
 
     it "can set ports for combined master/database/dashboard host" do
-      expect(ec2.amiports(all_in_one_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 8142, 443, 4433, 4435]
+      expect(ec2.amiports(all_in_one_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 8142, 8170, 443, 4433, 4435]
     end
   end
 end


### PR DESCRIPTION
The pe_acceptance_tests suite hits the code manager endpoint on primary
masters at 8170 during test runs. Prior to this patch, the ec2_helper
was generating a security group for master nodes which did not include
port 8170, and the
https://github.com/puppetlabs/pe_acceptance_tests/blob/2017.3.x/acceptance/tests/code-manager/deploy_with_code_manager_API.rb
test was failing when Scooter could not reach master:8170 from the beaker test
runner.

The patch just adds 8170 to the list of open ports on a master node.