### PR TITLE
(maint) Open the orchestrator port on the master node

### DIFF
--- a/lib/beaker/hypervisor/ec2_helper.rb
+++ b/lib/beaker/hypervisor/ec2_helper.rb
@@ -20,6 +20,7 @@ module Beaker
       if roles.include? 'master'
         ports << 8140
         ports << 8142
+        ports << 8143
         ports << 8170
       end
 

--- a/spec/beaker/hypervisor/ec2_helper_spec.rb
+++ b/spec/beaker/hypervisor/ec2_helper_spec.rb
@@ -30,7 +30,7 @@ describe Beaker::EC2Helper do
     end
 
     it "can set ports for master host" do
-      expect(ec2.amiports(master_host)).to be === [22, 61613, 8139, 8140, 8142, 8170, 9999]
+      expect(ec2.amiports(master_host)).to be === [22, 61613, 8139, 8140, 8142, 8143, 8170, 9999]
     end
 
     it "can set ports for dashboard host" do
@@ -38,7 +38,7 @@ describe Beaker::EC2Helper do
     end
 
     it "can set ports for combined master/database/dashboard host" do
-      expect(ec2.amiports(all_in_one_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 8142, 8170, 443, 4433, 4435]
+      expect(ec2.amiports(all_in_one_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 8142, 8143, 8170, 443, 4433, 4435]
     end
   end
 end


### PR DESCRIPTION
The pe_acceptance_tests reach out to the orchestrator service from the
beaker test host in
https://github.com/puppetlabs/pe_acceptance_tests/blob/2017.3.x/acceptance/tests/pe_checks/orchestrator_puppet_job_run.rb
This patch adds 8143 to the list of ports opened in the security group
beaker creates for ec2 hosts.