### PR TITLE
(BKR-1481) Rewrite beaker-aws to use shared .fog parsing

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -1046,8 +1046,7 @@ module Beaker
     # @return [Aws::Credentials] ec2 credentials
     # @api private
     def load_fog_credentials(dot_fog = '.fog')
-      fog = YAML.load_file( dot_fog )
-      default = fog[:default]
+      default = parse_fog_file(dot_fog)
 
       raise "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_access_key_id]
       raise "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_secret_access_key]

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -1046,7 +1046,7 @@ module Beaker
     # @return [Aws::Credentials] ec2 credentials
     # @api private
     def load_fog_credentials(dot_fog = '.fog')
-      default = parse_fog_file(dot_fog)
+      default = get_fog_credentials(dot_fog)
 
       raise "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_access_key_id]
       raise "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_secret_access_key]

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -1088,6 +1088,10 @@ module Beaker
       let(:dot_fog) { '.fog' }
       subject(:load_fog_credentials) { aws.load_fog_credentials(dot_fog) }
 
+      before do
+        expect(File).to receive(:exist?).with(dot_fog) { true }
+      end
+
       it 'returns loaded fog credentials' do
         creds = {:access_key_id => 'awskey', :secret_access_key => 'awspass', :session_token => nil}
         fog_hash = {:default => {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass'}}


### PR DESCRIPTION
See puppetlabs/beaker#1526. These changes will fail tests until the linked issue is merged (and released?).