### PR TITLE
Custom CIDRs for security group, none default VPC fixes

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -45,7 +45,7 @@ examples of AMI IDs, check out their
 [Amazon Linux AMI page](https://aws.amazon.com/amazon-linux-ami/).
 
 The `region-id` variable represents the EC2 region ID from AWS. For reference,
-checkout EC2's 
+checkout EC2's
 [Regions and Availability Zones page]
 (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
 An example of a region ID is `eu-west-1` for the Ireland data center.
@@ -72,7 +72,7 @@ The `host-vmname-value` references the ID created in the Amazon Image Config fil
 above.  If not provided, Beaker will try to name an AMI Config using the host's
 platform string.
 
-**Note:** If you are using `amazon-6-x86_64` as `vmname`, you have to specify `platform` as `el-6-x86_64`. Similarly for `amazon-6-i386` use `el-6-i386` as `platform`. 
+**Note:** If you are using `amazon-6-x86_64` as `vmname`, you have to specify `platform` as `el-6-x86_64`. Similarly for `amazon-6-i386` use `el-6-i386` as `platform`.
 
 The `type` references the type variable in the Amazon Image Config file as well,
 so this key picks out the particular AMI ID from the set available for this type
@@ -82,7 +82,7 @@ The `ami-size` variable refers to
 [instance types](https://aws.amazon.com/ec2/instance-types/) by their model name.
 Some examples of these values are "m3.large", "c4.xlarge", and "r3.8xlarge". The
 default value if this key is not provided used by Beaker is "m1.small".
-      
+
 ### ec2 VM Hostnames
 
 By default, beaker will set the hostnames of the VMs to the 'Public DNS' hostname supplied by ec2 (and which is normally based on the Public IP address). If your test requires the hosts be named identically to the `<hostname>:` from your beaker hosts file, set `:use_beaker_hostnames: true` in the beaker hosts file.
@@ -147,3 +147,8 @@ like so:
     [AWS EC2 200 0.142666 0 retries] describe_key_pairs(:filters=>[{:name=>"key-name",:values=>["Beaker-johnsmith-Johns-Ubuntu-2-local"]}])
 
 The values string in that line is what you're looking for.
+
+### Add custom CIDRs to security groups inbound rules
+
+Beaker creates 2 security groups to be able to access the EC2 instance. By default it defines inbound rules which allow access to everyone(0.0.0.0/0). In order to limit that access it is possible to configure the host param `sg_cidr_ips` which can be supplid with a list of CIDRs.
+

--- a/ec2.md
+++ b/ec2.md
@@ -34,7 +34,7 @@ hypervisor: ec2
       nfs_server: none
       consoleport: 443
 
-### Using role  
+### Using role
 *(If you'd like to use instance role you can disable reading fog credentials)*
 
 #### No fog file needed ####
@@ -67,7 +67,7 @@ Ports opened by default:
 * If you have a split install, all the hosts with `master`, `dashboard` and `database` role will have port 8143 opened
 
 ####`amisize` ####
-The [instance type](https://aws.amazon.com/ec2/instance-types/) - defaults to `m1.small`.  
+The [instance type](https://aws.amazon.com/ec2/instance-types/) - defaults to `m1.small`.
 ####`snapshot`####
 The snapshot to use for ec2 instance creation.
 ####`subnet_id`####
@@ -91,5 +91,17 @@ AMI:
 Size of the [EBS Volume](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html) that will be attached to the EC2 instance.
 ####`vpc_id`####
 ID of the [VPC](https://aws.amazon.com/vpc/) to create the instances in.  If not provided will either use the default VPC for the provided region (marked as `isDefault`), otherwise falls back to `nil`.  If subnet information is provided (`subnet_id`/`subnet_ids`) this must be defined.
-####`user`####
+
+#### `sg_cidr_ips` ####
+Comma seperated list of [CIDRs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html) which define the whitelisted IPs used by beaker. They will be added to the security groups which are created and associated with EC2 instance. Below is an example:
+
+```
+HOSTS:
+  somehostname:
+    sg_cidr_ips: 172.28.40.0/24,172.20.112.0/20
+```
+
+This is optional and by default is set to '0.0.0.0/0'.
+
+#### `user` ####
 By default root login is not allowed with Amazon Linux. Setting it to ec2-user will trigger `sshd_config` and `authorized_keys` changes by beaker.

--- a/ec2.md
+++ b/ec2.md
@@ -56,7 +56,7 @@ Beaker will automagically provision EC2 nodes, provided the 'platform:' section 
 ### Supported EC2 Variables ###
 These variables can either be set per-host or globally.
 
-####`additional_ports`####
+#### `additional_ports` ####
 Ports to be opened on the instance, in addition to those opened by Beaker to support Puppet functionality.  Can be a single value or an array.  Example valid values: 1001, [1001], [1001, 1002].
 
 Ports opened by default:
@@ -66,17 +66,22 @@ Ports opened by default:
 * `database` will also have [5432, 8080, 8081] opened
 * If you have a split install, all the hosts with `master`, `dashboard` and `database` role will have port 8143 opened
 
-####`amisize` ####
+#### `amisize` ####
 The [instance type](https://aws.amazon.com/ec2/instance-types/) - defaults to `m1.small`.
-####`snapshot`####
+
+#### `snapshot` ####
 The snapshot to use for ec2 instance creation.
-####`subnet_id`####
+
+#### `subnet_id` ####
 If defined the instance will be created in this EC2 subnet.  `vpc_id` must be defined.  Cannot be defined at the same time as `subnet_ids`.
-####`subnet_ids`####
+
+#### `subnet_ids` ####
 If defined the instace will be crated in one of the provided array of EC2 subnets.  `vpc_id` must be defined.  Cannot be defined at the same time as `subnet_id`.
-####`vmname`####
+
+#### `vmname` ####
 Used to look up the pre-defined AMI information in `config/image_templates/ec2.yaml`.  Will default to `platform` if not defined.
-#####Example ec2.yaml#####
+
+##### Example ec2.yaml #####
 In this example the `vmname` would be `puppetlabs-centos-5-x86-64-west`.  Looking up the `vmname` in the `ec2.yaml` file provides an AMI ID by type (`pe` or `foss`) and the region.
 
 ```
@@ -87,9 +92,10 @@ AMI:
     :region: us-west-2
 ```
 
-####`volume_size`####
+#### `volume_size` ####
 Size of the [EBS Volume](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html) that will be attached to the EC2 instance.
-####`vpc_id`####
+
+#### `vpc_id` ####
 ID of the [VPC](https://aws.amazon.com/vpc/) to create the instances in.  If not provided will either use the default VPC for the provided region (marked as `isDefault`), otherwise falls back to `nil`.  If subnet information is provided (`subnet_id`/`subnet_ids`) this must be defined.
 
 #### `sg_cidr_ips` ####


### PR DESCRIPTION
Without this changes, we encounter several issues:
- In the case of setting a custom 'vpc_id' and 'subnet_id' in the host
the ping security group gets created in the correct network and the other one in the
default vpc which is not desirable as the EC2 won't be able to use it

- Also given the security requirements in some companies using 0.0.0.0/0
might introduce security risks so being able to set CIDRs mitigates such
issues.

This commit introduces 'sg_cidr_ips' which can be added as a host
property and is a comma seperated list of CIDRs (e.g. 192.168.0.1/24,10.0.0.10/24)
I guess this might allow for adding other security groups as well.

Finally, replace 'security_groups' with 'security_group_ids' as AWS create
instance API call complains about groupName when the none default VPC is used.
A manual test has been made to make sure 'security_group_ids' works with default
VPC as well.