### PR TITLE
(BKR-1481) Rewrite beaker-aws to use shared .fog parsing

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -1075,8 +1075,7 @@ module Beaker
     # @return [Aws::Credentials] ec2 credentials
     # @api private
     def load_fog_credentials(dot_fog = '.fog')
-      fog = YAML.load_file( dot_fog )
-      default = fog[:default]
+      default = get_fog_credentials(dot_fog)
 
       raise "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_access_key_id]
       raise "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_secret_access_key]

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -1125,37 +1125,28 @@ module Beaker
       let(:dot_fog) { '.fog' }
       subject(:load_fog_credentials) { aws.load_fog_credentials(dot_fog) }
 
-      it 'returns loaded fog credentials' do
-        creds = {:access_key_id => 'awskey', :secret_access_key => 'awspass', :session_token => nil}
-        fog_hash = {:default => {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass'}}
+      it 'returns AWS::Credentials with loaded fog credentials and session token' do
+        fog_creds = {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass', :aws_session_token => 'sometoken'}
+        aws_creds = {:access_key_id => 'awskey', :secret_access_key => 'awspass', :session_token => 'sometoken'}
         expect(aws).to receive(:load_fog_credentials).and_call_original
-        expect(YAML).to receive(:load_file).and_return(fog_hash)
-        expect(load_fog_credentials).to have_attributes(creds)
-      end
-
-      it 'returns loaded fog credentials with session token' do
-        creds = {:access_key_id => 'awskey', :secret_access_key => 'awspass', :session_token => 'sometoken'}
-        fog_hash = {:default => {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass', :aws_session_token => 'sometoken'}}
-        expect(aws).to receive(:load_fog_credentials).and_call_original
-        expect(YAML).to receive(:load_file).and_return(fog_hash)
-        expect(load_fog_credentials).to have_attributes(creds)
+        expect(aws).to receive(:get_fog_credentials).and_return(fog_creds)
+        expect(load_fog_credentials).to have_attributes(aws_creds)
       end
 
       context 'raises errors' do
-        it 'if missing access_key credential' do
-          fog_hash = {:default => {:aws_secret_access_key => 'awspass'}}
+        it 'if missing aws_access_key_id credential' do
+          creds = {:aws_secret_access_key => 'awspass'}
           err_text = "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!"
           expect(aws).to receive(:load_fog_credentials).and_call_original
-          expect(YAML).to receive(:load_file).and_return(fog_hash)
+          expect(aws).to receive(:get_fog_credentials).and_return(creds)
           expect { load_fog_credentials }.to raise_error(err_text)
         end
 
-        it 'if missing secret_key credential' do
-          dot_fog = '.fog'
-          fog_hash = {:default => {:aws_access_key_id => 'awskey'}}
+        it 'if missing aws_secret_access_key credential' do
+          creds = {:aws_access_key_id => 'awskey'}
           err_text = "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!"
           expect(aws).to receive(:load_fog_credentials).and_call_original
-          expect(YAML).to receive(:load_file).and_return(fog_hash)
+          expect(aws).to receive(:get_fog_credentials).and_return(creds)
           expect { load_fog_credentials }.to raise_error(err_text)
         end
       end


### PR DESCRIPTION
See puppetlabs/beaker#1526. These changes will fail tests until the linked issue is merged (and released).

Previous PR got broken somehow.