### PR TITLE
BKR-1522 Add options to drop some of the provisioning

### DIFF
--- a/ec2.md
+++ b/ec2.md
@@ -111,3 +111,6 @@ This is optional and by default is set to '0.0.0.0/0'.
 
 #### `user` ####
 By default root login is not allowed with Amazon Linux. Setting it to ec2-user will trigger `sshd_config` and `authorized_keys` changes by beaker.
+
+#### `disable_root_ssh` ####
+By default Beaker enabled root login on the instance. There are situation where we use AMIs which are pre-configured. Setting `disable_root_ssh` to `true` will stop enablign the root login.


### PR DESCRIPTION
'disable_root_ssh' in case we don't want to configure root user

This is the case when using beaker with a Windows AMI which has openssh server
with a public key already set in the Administrator user. In that case beaker only needs
to import the public key to AWS and use it for ssh.

Also some of the provision steps namely set_hostnames and configure_hosts are not
compatible with windows and it's shell (cmd or Powershell). So this stops those
steps from running on windows platform.