### PR TITLE
(PDK-1275) fixes for the AWS hypervisor to account for netdev instances

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -544,7 +544,7 @@ module Beaker
           wait_for_status(nil, @hosts) do |instance|
             instance_status_collection = client.describe_instance_status({:instance_ids => [instance.instance_id]})
             first_instance = instance_status_collection.first[:instance_statuses].first
-            first_instance[:system_status][:status] == "ok" if first_instance
+            first_instance[:instance_status][:status] == "ok" if first_instance
           end
 
           break
@@ -737,10 +737,8 @@ module Beaker
       # disabling password policy to account for the enforcement level set
       # and the generated password is sometimes too `01070366:3: Bad password (admin): BAD PASSWORD: \
       # it is too simplistic/systematic`
-      # will be enabled after the password is set
       host.exec(Command.new('modify auth password-policy policy-enforcement disabled'))
       host.exec(Command.new("modify auth user admin password #{password}"))
-      host.exec(Command.new('modify auth password-policy policy-enforcement enabled'))
       @logger.notify("f5: Configured admin password to be #{password}")
       host.close
       host['ssh'] = {:password => password}

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -485,7 +485,7 @@ module Beaker
       # Wait for each node to reach status :running
       @logger.notify("aws-sdk: Waiting for all hosts to be #{state_name}")
       instances.each do |x|
-        name = x[:host].name
+        name = x[:host] ? x[:host].name : x[:name]
         instance = x[:instance]
         @logger.notify("aws-sdk: Wait for node #{name} to be #{state_name}")
         # Here we keep waiting for the machine state to reach 'running' with an

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -530,9 +530,9 @@ module Beaker
           wait_for_status(:running, @hosts)
 
           wait_for_status(nil, @hosts) do |instance|
-            instance_status_collection = instance.client.describe_instance_status({:instance_ids => [instance.instance_id]})
-            first_instance = instance_status_collection.reservations.first.instances.first
-            first_instance[:system_status][:status] == "ok"
+            instance_status_collection = client.describe_instance_status({:instance_ids => [instance.instance_id]})
+            first_instance = instance_status_collection.first[:instance_statuses].first
+            first_instance[:system_status][:status] == "ok" if first_instance
           end
 
           break

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -119,6 +119,7 @@ module Beaker
       before :each do
         expect(aws).to receive(:launch_all_nodes)
         expect(aws).to receive(:add_tags)
+        expect(aws).to receive(:modify_network_interface)
         expect(aws).to receive(:populate_dns)
         expect(aws).to receive(:enable_root_on_hosts)
         expect(aws).to receive(:set_hostnames)
@@ -702,7 +703,7 @@ module Beaker
         allow( aws ).to receive( :backoff_sleep )
         sha_mock = Object.new
         allow( Digest::SHA256 ).to receive( :new ).and_return(sha_mock)
-        expect( sha_mock ).to receive( :hexdigest ).once()
+        expect( sha_mock ).to receive( :hexdigest ).and_return('thistest').once()
         enable_root_f5
       end
 


### PR DESCRIPTION
During the work on adding F5 to our acceptance suite a few issues were encountered where these commits are addressing.

Mainly:

* the tagging of the instances after `wait_for_status` was too late in the process, especially for instances such as F5 which resulted in the centos and f5 instance to terminate as per AWS policies before it had a chance to set the `lifetime` tag, by tagging them before waiting for the status, it gives them a chance to boot up in to an `ok` state.

* the security groups were never assigned, they got created, but during the `create_instances` the `subnet_id` and `assoc_pub_ip_addr` is not available, which meant that the network_interface was never assigned the security_group which resulted in the default, which only allows ssh access - which defeats the purpose of having security_groups if you want to test different securities, so by modifying the interface at the correct stage it means that the instance gets the expected security groups.

https://github.com/puppetlabs/beaker-aws/compare/master...Thomas-Franklin:pdk-1275?expand=1#diff-4b62d9a6be807bf178a38d1ee3a1ad3bR500 is just a general tidy up, as the instance does not always have a `host` which led to nil pointer errors